### PR TITLE
Opera Mobile 12 compatibility

### DIFF
--- a/catberry_components/todo/input/template.hbs
+++ b/catberry_components/todo/input/template.hbs
@@ -1,3 +1,3 @@
 <form>
-	<input class="new-todo" placeholder="What needs to be done?" autofocus>
+	<input class="new-todo" placeholder="What needs to be done?" autofocus name="todo-input">
 </form>


### PR DESCRIPTION
In order to make _submit_ events to be emitted on Presto-based <a href="http://www.opera.com/ru/developer/mobile-emulator">Opera Mobile 12</a>
the <code>name</code> attribute is required in the text <code>input</code> tag.

Thanks to <a href="http://stackoverflow.com/questions/10853803/how-do-i-trigger-onsubmit-events-for-simple-forms-in-opera-mobile-with-a-virtu">StackOverflow</a> for this tip.