### PR TITLE
Move externals.js to S3.

### DIFF
--- a/catberry_components/head/head.hbs
+++ b/catberry_components/head/head.hbs
@@ -3,6 +3,5 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="lib/todomvc-app-css/index.css">
 <link rel="shortcut icon" href="favicon.ico">
-<script src="externals.js"></script>
+<script src="//s3.eu-central-1.amazonaws.com/catberry/todo.externals.min.js"></script>
 <script src="app.js"></script>
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "catberry-todomvc",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "TodoMVC implementation on Catberry Framework",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Now we can use full power of cache publishing externals.js to S3.